### PR TITLE
Polish grammar and fix various things

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-# Language Todo.TXT Plus - Syntax Highlight For Todo.TXT
+# Language Todo.TXT Plus - Syntax highlighting for Todo.TXT
 
 This is for comfort work with Todo.TXT-formatted `*.txt` files.
 
-If you doesn't know anything about Todo.TXT, go to [TodoTXT.com](http://todotxt.com) & read all about it! It's worth it :smile:
+If you don't know anything about Todo.TXT, go to [TodoTXT.com](http://todotxt.com) and read all about it! It's worth it. :smile:
 
 
 ## Features
 
 - Support of Ukrainian & Russian symbols
-- Add **comments**, **failed tasks**, **bold** & **itlaic** emphasis, **raw**, **strikethrought**
-- Projects, contexts & extensions can contant only letters & `-` (dash): `foo-bar:goo-moo @foo-bar +goo-moo`
-- Support of indentations
+- Add **comments**, **failed tasks**, **bold** & **italic** emphasis, **raw**, **strikethrough**
+- Projects, contexts and extensions can contain only letters and dashes: `foo-bar:goo-moo @foo-bar +goo-moo`
+- Support of indentation
 
   ```TodoTXT
   foo bar @Monaco
@@ -26,7 +26,7 @@ Syntax        | Description     | Example
 `**...**`     | Bold (strong)   | `bar **foo** goo`
 `_..._`       | italic (emphasis) | `bar _foo_ goo`
 `- ...`       | Failed task     | `- foo bar task @prj`
-`x ...`       | Complited task  | `x foo bar +task`
+`x ...`       | Completed task  | `x foo bar +task`
 `+{prj-name}` | Project         | `+foo-bar`, `+'foo bar'`
 `@{context}`  | Context         | `@foo-bar`, `@'foo bar'`
 `{param}:{value}` | Extension   | `some-param:some-value`, `param:'some value'`
@@ -57,9 +57,9 @@ foo `bar goo` hoo
 do some big project +project-name due:2017-12-31
   some part of the project @important
     deeper indention @too-deep
-  another **part** of the projec, with code `int main()`
-  x complited part of +project-name
-  - faild part
+  another **part** of the project, with code `int main()`
+  x completed part of +project-name
+  - failed part
   
 2017-07-06 this is another task with some-param:some-value
 x 2017-06-01 2016-05-21 due:2017-08-31 some ended task with ending date

--- a/grammars/todotxt.cson
+++ b/grammars/todotxt.cson
@@ -1,5 +1,5 @@
 'fileTypes': [
-  'txt'
+  'todo.txt'
 ]
 'name': 'TodoTXT'
 'patterns': [

--- a/grammars/todotxt.cson
+++ b/grammars/todotxt.cson
@@ -61,8 +61,12 @@
     # ```
     # t:yyyy-mm-dd
     # ```
-    'match': '(?<=\\s|[^0-9]|^)t:\\d{4}-\\d{2}-\\d{2}(?=\\s|[^0-9])'
+    'match': '(?<=\\s|[^0-9]|^)t(:)\\d{4}(-)\\d{2}(-)\\d{2}(?=\\s|[^0-9])'
     'name': 'constant.language.date.todotxt'
+    'captures':
+      '1': 'name': 'punctuation.separator.colon.key-value.todotxt'
+      '2': 'name': 'punctuation.separator.dash.date.todotxt'
+      '3': 'name': 'punctuation.separator.dash.date.todotxt'
   }
   {
     # Date 2
@@ -71,8 +75,11 @@
     # ```
     # yyyy-mm-dd
     # ```
-    'match': '(?<=\\s|[^0-9]|^)\\d{4}-\\d{2}-\\d{2}(?=\\s|[^0-9])'
+    'match': '(?<=\\s|[^0-9]|^)\\d{4}(-)\\d{2}(-)\\d{2}(?=\\s|[^0-9])'
     'name': 'constant.language.date.todotxt'
+    'captures':
+      '1': 'name': 'punctuation.separator.dash.date.todotxt'
+      '2': 'name': 'punctuation.separator.dash.date.todotxt'
   }
   {
     # Date time 1
@@ -81,8 +88,10 @@
     # ```
     # hh-mm
     # ```
-    'match': '(?<=\\s|[^0-9]|^)\\d{2}-\\d{2}(?=\\s|[^0-9])'
+    'match': '(?<=\\s|[^0-9]|^)\\d{2}(-)\\d{2}(?=\\s|[^0-9])'
     'name': 'constant.language.date.todotxt'
+    'captures':
+      '1': 'name': 'punctuation.separator.dash.date.todotxt'
   }
   {
     # Date time period
@@ -91,8 +100,12 @@
     # ```
     # hh-mm-hh-mm
     # ```
-    'match': '(?<=\\s|[^0-9]|^)\\d{2}-\\d{2}-\\d{2}-\\d{2}(?=\\s|[^0-9])'
+    'match': '(?<=\\s|[^0-9]|^)\\d{2}(-)\\d{2}(-)\\d{2}(-)\\d{2}(?=\\s|[^0-9])'
     'name': 'constant.language.date.todotxt'
+    'captures':
+      '1': 'name': 'punctuation.separator.dash.date.todotxt'
+      '2': 'name': 'punctuation.separator.dash.date.todotxt'
+      '3': 'name': 'punctuation.separator.dash.date.todotxt'
   }
   {
     # Due to date
@@ -101,8 +114,12 @@
     # ```
     # due:yyyy-mm-dd
     # ```
-    'match': '(?<=\\s|[^0-9]|^)due:\\d{4}-\\d{2}-\\d{2}(?=\\s|[^0-9])'
+    'match': '(?<=\\s|[^0-9]|^)due(:)\\d{4}(-)\\d{2}(-)\\d{2}(?=\\s|[^0-9])'
     'name': 'constant.language.due.todotxt'
+    'captures':
+      '1': 'name': 'punctuation.separator.colon.key-value.todotxt'
+      '2': 'name': 'punctuation.separator.dash.date.todotxt'
+      '3': 'name': 'punctuation.separator.dash.date.todotxt'
   }
   {
     # Extension
@@ -112,8 +129,10 @@
     # ```
     # bar goo-bar:foo-bar
     # ```
-    'match': '(?<!http:\\/\\/)(?<=[^-a-zA-Zа-яА-Я0-9ії]|^)[-a-zA-Zа-яА-Я0-9ії]+?:[-a-zA-Zа-яА-Я0-9ії]+?(?=[^-a-zA-Zа-яА-Я0-9ії])'
+    'match': '(?<!http:\\/\\/)(?<=[^-a-zA-Zа-яА-Я0-9ії]|^)[-a-zA-Zа-яА-Я0-9ії]+?(:)[-a-zA-Zа-яА-Я0-9ії]+?(?=[^-a-zA-Zа-яА-Я0-9ії])'
     'name': 'constant.language.extension.function.todotxt'
+    'captures':
+      '1': 'name': 'punctuation.separator.colon.key-value.todotxt'
   }
   {
     # Extension with quotes
@@ -122,8 +141,10 @@
     # ```
     # bar 'goo bar':'foo bar'
     # ```
-    'match': '(?<=^|[^-a-zA-Zа-яА-Я0-9ії])[-a-zA-Zа-яА-Я0-9ії]+?:\'.+?\'(?=\\S|\\s)'
+    'match': '(?<=^|[^-a-zA-Zа-яА-Я0-9ії])[-a-zA-Zа-яА-Я0-9ії]+?(:)\'.+?\'(?=\\S|\\s)'
     'name': 'constant.language.extension.function.todotxt'
+    'captures':
+      '1': 'name': 'punctuation.separator.colon.key-value.todotxt'
   }
   {
     # Context
@@ -133,8 +154,10 @@
     # foo bar @goo
     # bar @foo-boo
     # ```
-    'match': '(?<=[^-a-zA-Zа-яА-Я0-9ії]|^)@[-a-zA-Zа-яА-Я0-9ії]+?(?=[^-a-zA-Zа-яА-Я0-9ії])'
+    'match': '(?<=[^-a-zA-Zа-яА-Я0-9ії]|^)(@)[-a-zA-Zа-яА-Я0-9ії]+?(?=[^-a-zA-Zа-яА-Я0-9ії])'
     'name': 'entity.name.tag.context.keyword.todotxt'
+    'captures':
+      '1': 'name': 'punctuation.definition.variable.todotxt'
   }
   {
     # Context with quotes
@@ -143,8 +166,10 @@
     # ```
     # bar @'foo bar'
     # ```
-    'match': '(?<=^|\\s|\\S)@\'.+?\'(?=\\S|\\s)'
+    'match': '(?<=^|\\s|\\S)(@)\'.+?\'(?=\\S|\\s)'
     'name': 'entity.name.tag.context.keyword.todotxt'
+    'captures':
+      '1': 'name': 'punctuation.definition.variable.todotxt'
   }
   {
     # Project
@@ -154,8 +179,10 @@
     # foo bar +goo
     # bar +foo-boo
     # ```
-    'match': '(?<=[^-a-zA-Zа-яА-Я0-9ії]|^)\\+[-a-zA-Zа-яА-Я0-9ії]+?(?=[^-a-zA-Zа-яА-Я0-9ії])'
+    'match': '(?<=[^-a-zA-Zа-яА-Я0-9ії]|^)(\\+)[-a-zA-Zа-яА-Я0-9ії]+?(?=[^-a-zA-Zа-яА-Я0-9ії])'
     'name': 'entity.name.tag.project.variable.todotxt'
+    'captures':
+      '1': 'name': 'punctuation.definition.variable.todotxt'
   }
   {
     # Project with quotes
@@ -174,7 +201,7 @@
     # ```
     # x foo bar
     # ```
-    'match': '^\\s*?(x|х|х)\\s.*$'
+    'match': '^\\s*(x|х)\\s.*$'
     'name': 'comment.line.todotxt'
   }
   {
@@ -196,7 +223,9 @@
     # # foo bar
     # bar bar  # goo
     # ```
-    'match': '#.*$'
-    'name': 'comment.line.todotxt'
+    'match': '(#).*$'
+    'name': 'comment.line.number-sign.todotxt'
+    'captures':
+      '1': 'name': 'punctuation.definition.comment.todotxt'
   }
 ]

--- a/grammars/todotxt.cson
+++ b/grammars/todotxt.cson
@@ -1,7 +1,8 @@
+'name': 'TodoTXT'
+'scopeName': 'text.todotxt'
 'fileTypes': [
   'todo.txt'
 ]
-'name': 'TodoTXT'
 'patterns': [
   {
     # Strikethrough
@@ -51,7 +52,7 @@
     # A foo bar
     # ```
     'match': '^\\s*?\\([A-Z]\\)'
-    'name': 'constant.language.todotxt.priority'
+    'name': 'constant.language.priority.todotxt'
   }
   {
     # Date 1
@@ -61,7 +62,7 @@
     # t:yyyy-mm-dd
     # ```
     'match': '(?<=\\s|[^0-9]|^)t:\\d{4}-\\d{2}-\\d{2}(?=\\s|[^0-9])'
-    'name': 'constant.language.todotxt.date'
+    'name': 'constant.language.date.todotxt'
   }
   {
     # Date 2
@@ -71,7 +72,7 @@
     # yyyy-mm-dd
     # ```
     'match': '(?<=\\s|[^0-9]|^)\\d{4}-\\d{2}-\\d{2}(?=\\s|[^0-9])'
-    'name': 'constant.language.todotxt.date'
+    'name': 'constant.language.date.todotxt'
   }
   {
     # Date time 1
@@ -81,7 +82,7 @@
     # hh-mm
     # ```
     'match': '(?<=\\s|[^0-9]|^)\\d{2}-\\d{2}(?=\\s|[^0-9])'
-    'name': 'constant.language.todotxt.date'
+    'name': 'constant.language.date.todotxt'
   }
   {
     # Date time period
@@ -91,7 +92,7 @@
     # hh-mm-hh-mm
     # ```
     'match': '(?<=\\s|[^0-9]|^)\\d{2}-\\d{2}-\\d{2}-\\d{2}(?=\\s|[^0-9])'
-    'name': 'constant.language.todotxt.date'
+    'name': 'constant.language.date.todotxt'
   }
   {
     # Due to date
@@ -101,7 +102,7 @@
     # due:yyyy-mm-dd
     # ```
     'match': '(?<=\\s|[^0-9]|^)due:\\d{4}-\\d{2}-\\d{2}(?=\\s|[^0-9])'
-    'name': 'constant.language.todotxt.due'
+    'name': 'constant.language.due.todotxt'
   }
   {
     # Extension
@@ -112,7 +113,7 @@
     # bar goo-bar:foo-bar
     # ```
     'match': '(?<!http:\\/\\/)(?<=[^-a-zA-Zа-яА-Я0-9ії]|^)[-a-zA-Zа-яА-Я0-9ії]+?:[-a-zA-Zа-яА-Я0-9ії]+?(?=[^-a-zA-Zа-яА-Я0-9ії])'
-    'name': 'constant.language.todotxt.extension.function'
+    'name': 'constant.language.extension.function.todotxt'
   }
   {
     # Extension with quotes
@@ -122,7 +123,7 @@
     # bar 'goo bar':'foo bar'
     # ```
     'match': '(?<=^|[^-a-zA-Zа-яА-Я0-9ії])[-a-zA-Zа-яА-Я0-9ії]+?:\'.+?\'(?=\\S|\\s)'
-    'name': 'constant.language.todotxt.extension.function'
+    'name': 'constant.language.extension.function.todotxt'
   }
   {
     # Context
@@ -133,7 +134,7 @@
     # bar @foo-boo
     # ```
     'match': '(?<=[^-a-zA-Zа-яА-Я0-9ії]|^)@[-a-zA-Zа-яА-Я0-9ії]+?(?=[^-a-zA-Zа-яА-Я0-9ії])'
-    'name': 'entity.name.tag.todotxt.context.keyword'
+    'name': 'entity.name.tag.context.keyword.todotxt'
   }
   {
     # Context with quotes
@@ -143,7 +144,7 @@
     # bar @'foo bar'
     # ```
     'match': '(?<=^|\\s|\\S)@\'.+?\'(?=\\S|\\s)'
-    'name': 'entity.name.tag.todotxt.context.keyword'
+    'name': 'entity.name.tag.context.keyword.todotxt'
   }
   {
     # Project
@@ -154,7 +155,7 @@
     # bar +foo-boo
     # ```
     'match': '(?<=[^-a-zA-Zа-яА-Я0-9ії]|^)\\+[-a-zA-Zа-яА-Я0-9ії]+?(?=[^-a-zA-Zа-яА-Я0-9ії])'
-    'name': 'entity.name.tag.todotxt.project.variable'
+    'name': 'entity.name.tag.project.variable.todotxt'
   }
   {
     # Project with quotes
@@ -164,7 +165,7 @@
     # bar +'foo bar'
     # ```
     'match': '(?<=^|\\s|\\S)\\+\'.+?\'(?=\\S|\\s)'
-    'name': 'entity.name.tag.todotxt.project.variable'
+    'name': 'entity.name.tag.project.variable.todotxt'
   }
   {
     # Allow Cyrillic letter 'x'
@@ -199,4 +200,3 @@
     'name': 'comment.line.todotxt'
   }
 ]
-'scopeName': 'text.todotxt'


### PR DESCRIPTION
I noticed this grammar was affecting *every* `.txt` file I opened, regardless of whether it was "TodoTXT-formatted" or not. I updated the `fileTypes` array to only affect files named `todo.txt` (which is the expected behaviour).

I also polished a few things I could see needed improvement, namely:

* Spelling and grammar mistakes
* Inconsistent ordering of base scopes: `foo.todotxt.bar` -> `foo.bar.todotxt`
* Capturing groups added to improve appearance of punctuation in themes which shade them differently. Some themes like [`duotone`](https://atom.io/themes/duotone-light-syntax) and [`seti-syntax`](https://atom.io/themes/seti-syntax) colour such symbols so they're less distracting.
